### PR TITLE
Installation docs [2]

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -32,6 +32,10 @@ We strongly recommend installing TARDIS ecosystem packages using this method by 
    .. code-block:: bash
 
        conda activate tardis
+   
+   .. note::
+   This environment works for all TARDIS ecosystem packages. No additional environments are required.
+
 
 4. To install TARDIS ecosystem packages, first execute these commands:
 
@@ -97,9 +101,6 @@ We strongly recommend installing TARDIS ecosystem packages using this method by 
           $ pip install -e ".[tardisbase]" --upgrade --force-reinstall # forces reinstall of tardisbase dependencies group
       
       Please refer to the package documentation for more details.
-
-.. note::
-   This environment works for all TARDIS ecosystem packages. No additional environments are required.
 
 To update the environment:
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -2,15 +2,16 @@ Installation
 -----------
 
 .. note::
-    - tardisbase is only supported on macOS and GNU/Linux.
-    - TARDIS dependencies are distributed only through the `conda <https://docs.conda.io/en/latest/>`_ 
+    - tardisbase and TARDIS ecosystem packages are only supported on macOS and GNU/Linux. Windows users can run TARDIS ecosystem packages 
+      from our official Docker image (*coming soon*), `WSL <https://docs.microsoft.com/en-us/windows/wsl/>`_ 
+      or a Virtual Machine.
+    - TARDIS ecosystem package dependencies are distributed only through the `conda <https://docs.conda.io/en/latest/>`_ 
       package management system, therefore installation requires `Anaconda <https://docs.anaconda.com/anaconda/install/index.html>`_ 
       or `Miniconda <https://conda.io/projects/conda/en/latest/user-guide/install/index.html>`_
       to be installed on your system.
 
-Conda lockfiles are platform-specific dependency files that produce repeatable environments.
-These files are generated on every new release. We strongly recommend installing TARDIS ecosystem
-packages using this method by following the steps described below.
+Conda lockfiles are platform-specific dependency files that produce reproducible environments. 
+We strongly recommend installing TARDIS ecosystem packages using this method by following the steps below.
 
 1. Download the lockfile for your platform:
 
@@ -32,7 +33,7 @@ packages using this method by following the steps described below.
 
        conda activate tardis
 
-4. a. Developers should `fork the repository <https://github.com/tardis-sn/{package}/fork>`_, configure
+4. a. Developers should `fork the repository <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_, configure
       GitHub to `work with SSH keys <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_,
       set up the `upstream remote <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork>`_,
       and install the package in development mode.
@@ -65,6 +66,18 @@ packages using this method by following the steps described below.
       .. code-block:: bash
 
         $ pip install git+https://github.com/tardis-sn/{package}.git@master
+        
+      .. warning::
+        Running specific modules or tests for some packages might require additional optional dependencies. 
+        These optional dependencies can be installed by running:
+        
+        .. code-block:: bash
+        
+          $ pip install -e ".[optional_dependencies]"
+          # for example:
+          $ pip install -e ".[viz]" # installs qgridnext and lineid_plot in tardis for visualization widgets.
+        
+        Please refer to the package documentation for more details.
 
 .. note::
    This environment works for all TARDIS ecosystem packages. No additional environments are required.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -75,17 +75,28 @@ We strongly recommend installing TARDIS ecosystem packages using this method by 
 
         $ pip install git+https://github.com/tardis-sn/{package}.git@master
         
-      .. warning::
-        Running specific modules or tests for some packages might require additional optional dependencies. 
-        These optional dependencies can be installed by running:
-        
-        .. code-block:: bash
-        
-          $ pip install -e ".[optional_dependencies]"
+    .. note::
+      Running specific modules or tests for some packages might require additional optional dependencies. 
+      The tardisbase package can also be installed as an optional dependency.
+      These optional dependencies can be installed by running:
+      
+      .. code-block:: bash
+      
+        $ pip install -e ".[optional_dependencies]"
+        # for example:
+        # pip install -e ".[tardisbase]" # installs the package with tardisbase optional dependency group
+        # for multiple optional dependencies
+        # $ pip install -e ".[dependency1,dependency2,dependency3]"
+
+      To update optional dependencies, use:
+
+      .. code-block:: bash
+      
+          $ pip install -e ".[optional_dependency]" --upgrade --force-reinstall
           # for example:
-          $ pip install -e ".[viz]" # installs qgridnext and lineid_plot in tardis for visualization widgets.
-        
-        Please refer to the package documentation for more details.
+          $ pip install -e ".[tardisbase]" --upgrade --force-reinstall # forces reinstall of tardisbase dependencies group
+      
+      Please refer to the package documentation for more details.
 
 .. note::
    This environment works for all TARDIS ecosystem packages. No additional environments are required.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -100,10 +100,38 @@ We strongly recommend installing TARDIS ecosystem packages using this method by 
           # for example:
           $ pip install -e ".[tardisbase]" --upgrade --force-reinstall # forces reinstall of tardisbase dependencies group
       
-      Please refer to the package documentation for more details.
+      See the package documentation for a complete list of optional dependencies for that package.
 
-To update the environment:
+
+Environment update
+==================
+
+To update the environment, download the latest lockfile and run ``conda update``.
 
 .. code-block:: bash
 
-    conda update --name tardis --file conda-{platform}.lock
+    $ wget -q https://github.com/tardis-sn/tardisbase/master/conda-{platform}-64.lock
+    $ conda update --name tardis --file conda-{platform}.lock
+
+.. note::
+
+  If you have installed the package in development mode, you should *ideally* update your environment whenever you pull latest package code because the new code added might be using updated (or new) dependencies. If you don't do that and your installation seems broken, you can check if your environment requires update by comparing it against the latest environment file:
+
+  .. code-block:: bash
+
+      $ conda compare --name tardis env.yml
+   
+  We also recommend updating optional dependencies whenever you pull latest code.
+
+
+**Recommended approach:**
+
+We highly recommend deleting your existing environment and creating a new one using the latest lockfile whenever you need to update your environment.
+
+Use the following ``conda`` command to remove your current ``tardis`` environment:
+
+.. code-block:: bash
+
+    $ conda remove --name tardis --all
+
+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,7 +11,10 @@ Installation
       to be installed on your system.
 
 Conda lockfiles are platform-specific dependency files that produce reproducible environments. 
-We strongly recommend installing TARDIS ecosystem packages using this method by following the steps below.
+We strongly recommend installing `tardisbase` using this method by following the steps below.
+
+.. note::
+    You need not install the environment if you have installed it already beforehand when installing a different TARDIS ecosystem package.
 
 1. Download the lockfile for your platform:
 
@@ -37,25 +40,22 @@ We strongly recommend installing TARDIS ecosystem packages using this method by 
    This environment works for all TARDIS ecosystem packages. No additional environments are required.
 
 
-4. To install TARDIS ecosystem packages, first execute these commands:
-
-   .. note::
-      Replace {package} with the name of the TARDIS package you wish to install.
+4. To install `tardisbase` first execute these commands:
 
    .. code-block:: bash
 
-      $ git clone git@github.com:tardis-sn/{package}.git
-      $ cd {package}
-      $ git remote add upstream git@github.com:tardis-sn/{package}.git
+      $ git clone git@github.com:tardis-sn/tardisbase.git
+      $ cd tardisbase
+      $ git remote add upstream git@github.com:tardis-sn/tardisbase.git
       $ git fetch upstream
       $ git checkout upstream/master
     
    The installation process differs for developers and non-developers:
 
-   a. Developers should `fork the repository <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_ of the package to be installed, configure
+   a. Developers should `fork the repository <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_ , configure
       GitHub to `work with SSH keys <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_,
-      set up the `upstream remote <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork>`_,
-      and install the package in development mode.
+      set up the `upstream remote <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork>`_ and `origin` (pointing to your fork),
+      and install `tardisbase` in development mode.
 
       .. code-block:: bash
 
@@ -65,43 +65,19 @@ We strongly recommend installing TARDIS ecosystem packages using this method by 
 
       .. code-block:: bash
 
-        $ pip install git+https://github.com/tardis-sn/{package}.git@{tag}
+        $ pip install git+https://github.com/tardis-sn/tardisbase.git@{tag}
 
       For example, to install the latest release:
 
       .. code-block:: bash
       
-        $ pip install git+https://github.com/tardis-sn/{package}.git@release-latest
+        $ pip install git+https://github.com/tardis-sn/tardisbase.git@release-latest
 
       or to install the most recent, unreleased changes from upstream:
 
       .. code-block:: bash
 
-        $ pip install git+https://github.com/tardis-sn/{package}.git@master
-        
-    .. note::
-      Running specific modules or tests for some packages might require additional optional dependencies. 
-      The tardisbase package can also be installed as an optional dependency.
-      These optional dependencies can be installed by running:
-      
-      .. code-block:: bash
-      
-        $ pip install -e ".[optional_dependencies]"
-        # for example:
-        # pip install -e ".[tardisbase]" # installs the package with tardisbase optional dependency group
-        # for multiple optional dependencies
-        # $ pip install -e ".[dependency1,dependency2,dependency3]"
-
-      To update optional dependencies, use:
-
-      .. code-block:: bash
-      
-          $ pip install -e ".[optional_dependency]" --upgrade --force-reinstall
-          # for example:
-          $ pip install -e ".[tardisbase]" --upgrade --force-reinstall # forces reinstall of tardisbase dependencies group
-      
-      See the package documentation for a complete list of optional dependencies for that package.
-
+        $ pip install git+https://github.com/tardis-sn/tardisbase.git@master
 
 Environment update
 ==================
@@ -115,7 +91,7 @@ To update the environment, download the latest lockfile and run ``conda update``
 
 .. note::
 
-  If you have installed the package in development mode, you should *ideally* update your environment whenever you pull latest package code because the new code added might be using updated (or new) dependencies. If you don't do that and your installation seems broken, you can check if your environment requires update by comparing it against the latest environment file:
+  If you have installed `tardisbase` in development mode, you should *ideally* update your environment whenever you pull latest code because the new code added might be using updated (or new) dependencies. If you don't do that and your installation seems broken, you can check if your environment requires update by comparing it against the latest environment file:
 
   .. code-block:: bash
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,22 +33,30 @@ We strongly recommend installing TARDIS ecosystem packages using this method by 
 
        conda activate tardis
 
-4. a. Developers should `fork the repository <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_, configure
+4. To install TARDIS ecosystem packages, first execute these commands:
+
+   .. note::
+      Replace {package} with the name of the TARDIS package you wish to install.
+
+   .. code-block:: bash
+
+      $ git clone git@github.com:tardis-sn/{package}.git
+      $ cd {package}
+      $ git remote add upstream git@github.com:tardis-sn/{package}.git
+      $ git fetch upstream
+      $ git checkout upstream/master
+    
+   The installation process differs for developers and non-developers:
+
+   a. Developers should `fork the repository <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo>`_ of the package to be installed, configure
       GitHub to `work with SSH keys <https://docs.github.com/en/authentication/connecting-to-github-with-ssh>`_,
       set up the `upstream remote <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/configuring-a-remote-for-a-fork>`_,
       and install the package in development mode.
 
       .. code-block:: bash
 
-        $ git clone git@github.com:<username>/{package}.git
-        $ cd {package}
-        $ git remote add upstream git@github.com:tardis-sn/{package}.git
-        $ git fetch upstream
-        $ git checkout upstream/master
         $ pip install -e .
 
-      Replace ``{package}`` with tardis, stardis, carsus, or tardisbase.
-        
    b. Non-developers can install from specific releases using pip:
 
       .. code-block:: bash


### PR DESCRIPTION
This pull request updates the installation instructions for `tardisbase` and other TARDIS ecosystem packages in the `docs/installation.rst` file. The changes clarify support for Windows users, streamline installation steps, and provide detailed guidance for environment updates.

### Installation Instructions Updates:

* Expanded support for Windows users by introducing options like Docker, WSL, and Virtual Machines for running TARDIS ecosystem packages.
* Simplified installation steps for developers and non-developers, with explicit instructions for cloning and installing `tardisbase` using `pip`.

### Environment Management Enhancements:

* Added detailed instructions for updating the `tardis` environment, including commands for downloading the latest lockfile, updating dependencies, and comparing environments.
* Recommended a clean environment recreation approach for updates, emphasizing the use of the latest lockfile to ensure compatibility.