### PR TITLE
add plugin to display writing symbol and not skip test

### DIFF
--- a/tardisbase/testing/regression_data/regression_data.py
+++ b/tardisbase/testing/regression_data/regression_data.py
@@ -105,7 +105,6 @@ class RegressionData:
         self.fname = f"{self.fname_prefix}.npy"
         if self.enable_generate_reference:
             self.fpath.parent.mkdir(parents=True, exist_ok=True)
-            self.fpath.parent.mkdir(parents=True, exist_ok=True)
             np.save(self.fpath, data)
             write_status()
         else:

--- a/tardisbase/testing/regression_data/regression_data.py
+++ b/tardisbase/testing/regression_data/regression_data.py
@@ -223,4 +223,4 @@ class PytestWritingPlugin:
 
     def pytest_report_teststatus(self, report, config):
         if hasattr(report, "written") and report.written:
-            return ("written", "W", "WRITTEN")
+            return ("regression data written", "W", "WRITTEN")


### PR DESCRIPTION
This should be merged with https://github.com/tardis-sn/tardis/pull/3152

This adds a plugin to change the behavior of the --generate-reference flag. Instead of calling pyest.skip() which immediately terminates the test, the test should continue with this and display a W and log the test with the "written" status. 

This should specifically enable the behavior where you can do regression_data.sync_dataframe() on a test, and pass a different key, so that multiple dataframes can be saved to the same hdf file for the same test. 