### PR TITLE
mention intel lockfile and tabs for different platforms to install docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,6 +35,7 @@ extensions = [
     "sphinx_automodapi.automodapi",
     "sphinx_automodapi.smart_resolver",
     "sphinxcontrib.apidoc",
+    "sphinx_tabs.tabs"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -16,17 +16,53 @@ We strongly recommend installing `tardisbase` using this method by following the
 
 1. Download the lockfile for your platform:
 
-   .. code-block:: bash
+   .. tabs:: 
 
-       wget -q https://github.com/tardis-sn/tardisbase/master/conda-{platform}-64.lock
+      .. group-tab:: OSX (Arm CPU)
 
-   Replace ``{platform}`` with ``linux-64`` or ``osx-arm64`` based on your operating system.
+        .. code-block:: bash
+
+            wget -q https://github.com/tardis-sn/tardisbase/master/conda-osx-arm64.lock
+        
+      
+      .. group-tab:: Linux
+
+        .. code-block:: bash
+
+            wget -q https://github.com/tardis-sn/tardisbase/master/conda-linux-64.lock
+      
+      .. group-tab:: OSX (Intel CPU)
+
+        .. code-block:: bash
+
+            wget -q https://github.com/tardis-sn/tardisbase/master/conda-osx-64.lock
+        
+        .. warning::
+            Use at your own risk. This lockfile is not tested, so we recommend running the tests before using any of the TARDIS ecosystem packages with this environment.
 
 2. Create the environment:
 
-   .. code-block:: bash
+   .. tabs:: 
 
-       conda create --name tardis --file conda-{platform}.lock
+      .. group-tab:: OSX (Arm CPU)
+
+        .. code-block:: bash
+
+            conda create --name tardis --file conda-osx-arm64.lock
+        
+      
+      .. group-tab:: Linux
+
+        .. code-block:: bash
+
+            conda create --name tardis --file conda-linux-64.lock
+      
+      .. group-tab:: OSX (Intel CPU)
+
+        .. code-block:: bash
+
+            conda create --name tardis --file conda-osx-64.lock
+   
 
 3. Activate the environment:
 


### PR DESCRIPTION
### :pencil: Description

**Type:**:memo: `documentation` 

Adds the intel cpu lockfile to the installation instructions and uses [`sphinx-tabs`](https://sphinx-tabs.readthedocs.io/en/latest/) to have tabs per platform. (like in `tardis` [PR#3158](https://github.com/tardis-sn/tardis/pull/3158)

<img width="617" alt="Screenshot 2025-06-23 at 7 40 01 PM" src="https://github.com/user-attachments/assets/0e73c672-7456-4451-a7b8-272988e9efa6" />
