### PR TITLE
Fix docs build workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -112,6 +112,7 @@ jobs:
           user_email: "tardis.sn.bot@gmail.com"
 
       - uses: tardis-sn/tardis-actions/setup-docs-comments@main
+        if: ${{ github.event_name == 'pull_request_target' }}
         with:
           bot-token: ${{ secrets.BOT_TOKEN }}
           repository: ${{ github.repository }}


### PR DESCRIPTION
### :pencil: Description

**Type:** :beetle: `bugfix` | :rocket: `feature` | :biohazard: `breaking change` | :vertical_traffic_light: `testing` | :memo: `documentation` | :roller_coaster: `infrastructure`

The comment action tries to comment even on a push event which causes the workflow to fail. Adding an if condition fixes it.
Fixes: https://github.com/tardis-sn/tardisbase/issues/18
Sample run: https://github.com/KasukabeDefenceForce/tardisbase/actions/runs/15870866808/job/44746886037
### :pushpin: Resources

Examples, notebooks, and links to useful references.


### :vertical_traffic_light: Testing

How did you test these changes?

- [ ] Testing pipeline
- [ ] Other method (describe)
- [ ] My changes can't be tested (explain why)


### :ballot_box_with_check: Checklist

- [ ] I requested two reviewers for this pull request
- [ ] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label

> **Note:** If you are not allowed to perform any of these actions, ping (@) a contributor.
