### PR TITLE
mention the intel lockfile in the installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,11 @@ We strongly recommend installing `tardisbase` using this method by following the
 
        wget -q https://github.com/tardis-sn/tardisbase/master/conda-{platform}-64.lock
 
-   Replace ``{platform}`` with ``linux-64`` or ``osx-arm64`` based on your operating system.
+   Replace ``{platform}`` with ``linux-64``, ``osx-arm64``, or ``osx-64`` (Mac Intel CPU) based on your operating system and CPU architecture.
+
+   .. warning::
+            Use the ``conda-osx-64.lock`` at your own risk. This lockfile is not tested, so we recommend :ref:`running the tests <running-tests>` before using any of the TARDIS ecosystem packages with this environment. 
+
 
 2. Create the environment:
 


### PR DESCRIPTION
### :pencil: Description

**Type:**  :memo: `documentation`

Updated the installation documentation to mention the existence of the lockfile for Mac's with Intel CPUs.  Also, includes a warning about the lockfile not being tested.

Before:
<img width="622" alt="Screenshot 2025-06-27 at 11 01 15 AM" src="https://github.com/user-attachments/assets/3006c1aa-5359-4a42-bb9f-9a34a3029bd5" />

After:
<img width="610" alt="Screenshot 2025-06-27 at 10 59 16 AM" src="https://github.com/user-attachments/assets/ca1ade5b-f934-4e4e-b367-2f39e5bc5001" />


### :ballot_box_with_check: Checklist

- [x] I requested two reviewers for this pull request
- [x] I updated the documentation according to my changes
- [ ] I built the documentation by applying the `build_docs` label